### PR TITLE
feat(formatter): print no color display log level

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -165,13 +165,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 }
 
 func (f *TextFormatter) printNoColored(b *bytes.Buffer, entry *logrus.Entry, keys []string, timestampFormat string) {
-	var levelText string
-
-	if entry.Level != logrus.WarnLevel {
-		levelText = strings.ToUpper(entry.Level.String())
-	} else {
-		levelText = "WARN"
-	}
+	levelText := entry.Level.String()
 
 	prefix := " "
 	message := entry.Message
@@ -193,9 +187,9 @@ func (f *TextFormatter) printNoColored(b *bytes.Buffer, entry *logrus.Entry, key
 	}
 
 	if f.ShortTimestamp {
-		fmt.Fprintf(b, "[%s %04d %s]%s"+messageFormat, levelText[:1], miniTS(), caller, prefix, message)
+		fmt.Fprintf(b, "[%s %04d %s]%s"+messageFormat, levelText, miniTS(), caller, prefix, message)
 	} else {
-		fmt.Fprintf(b, "[%s %s %s]%s"+messageFormat, levelText[:1], entry.Time.Format(timestampFormat), caller, prefix, message)
+		fmt.Fprintf(b, "[%s %s %s]%s"+messageFormat, levelText, entry.Time.Format(timestampFormat), caller, prefix, message)
 	}
 	for _, k := range keys {
 		v := entry.Data[k]


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

现在使用 grafana 展示日志，为了更好的分类，根据 https://grafana.com/docs/grafana/latest/explore/#log-level ，打印具体的 log level

打印的 format 将变为:
[I  => [info
[E => [error
[W => [warning
[F => [fatal

效果如下：
![image](https://user-images.githubusercontent.com/10767027/101720454-a4fc1000-3ae0-11eb-958a-a911ff0d2e49.png)

如果不这样改动，我们原来的日志都会被归为 unknown 级别

/cc @yousong @wanyaoqi 